### PR TITLE
fix: callback signature need to have error as first param

### DIFF
--- a/Bean/beanScratch.js
+++ b/Bean/beanScratch.js
@@ -59,7 +59,11 @@ module.exports = function(RED) {
                 if (node.readOne) {
                     tasks.push(function(callback) {
                         node.bean.readOne(function(error, data) {
-                            msg[node.property1] = valueOf(data, node.type1);
+                            if (error) {
+                                node.error(error);
+                            } else {
+                                msg[node.property1] = valueOf(data, node.type1);
+                            }
                             callback(null);
                         });
                     });
@@ -67,7 +71,11 @@ module.exports = function(RED) {
                 if (node.readTwo) {
                     tasks.push(function(callback) {
                         node.bean.readTwo(function(error, data) {
-                            msg[node.property2] = valueOf(data, node.type2);
+                            if (error) {
+                                node.error(error);
+                            } else {
+                                msg[node.property2] = valueOf(data, node.type2);
+                            }
                             callback(null);
                         });
                     });
@@ -75,7 +83,11 @@ module.exports = function(RED) {
                 if (node.readThree) {
                     tasks.push(function(callback) {
                         node.bean.readThree(function(error, data) {
-                            msg[node.property3] = valueOf(data, node.type3);
+                            if (error) {
+                                node.error(error);
+                            } else {
+                                msg[node.property3] = valueOf(data, node.type3);
+                            }
                             callback(null);
                         });
                     });
@@ -83,7 +95,11 @@ module.exports = function(RED) {
                 if (node.readFour) {
                     tasks.push(function(callback) {
                         node.bean.readFour(function(error, data) {
-                            msg[node.property4] = valueOf(data, node.type4);
+                            if (error) {
+                                node.error(error);
+                            } else {
+                                msg[node.property4] = valueOf(data, node.type4);
+                            }
                             callback(null);
                         });
                     });
@@ -91,7 +107,11 @@ module.exports = function(RED) {
                 if (node.readFive) {
                     tasks.push(function(callback) {
                         node.bean.readFive(function(error, data) {
-                            msg[node.property5] = valueOf(data, node.type5);
+                            if (error) {
+                                node.error(error);
+                            } else {
+                                msg[node.property5] = valueOf(data, node.type5);
+                            }
                             callback(null);
                         });
                     });

--- a/Bean/beanScratch.js
+++ b/Bean/beanScratch.js
@@ -58,7 +58,7 @@ module.exports = function(RED) {
                 var tasks = [];
                 if (node.readOne) {
                     tasks.push(function(callback) {
-                        node.bean.readOne(function(data) {
+                        node.bean.readOne(function(error, data) {
                             msg[node.property1] = valueOf(data, node.type1);
                             callback(null);
                         });
@@ -66,7 +66,7 @@ module.exports = function(RED) {
                 }
                 if (node.readTwo) {
                     tasks.push(function(callback) {
-                        node.bean.readTwo(function(data) {
+                        node.bean.readTwo(function(error, data) {
                             msg[node.property2] = valueOf(data, node.type2);
                             callback(null);
                         });
@@ -74,7 +74,7 @@ module.exports = function(RED) {
                 }
                 if (node.readThree) {
                     tasks.push(function(callback) {
-                        node.bean.readThree(function(data) {
+                        node.bean.readThree(function(error, data) {
                             msg[node.property3] = valueOf(data, node.type3);
                             callback(null);
                         });
@@ -82,7 +82,7 @@ module.exports = function(RED) {
                 }
                 if (node.readFour) {
                     tasks.push(function(callback) {
-                        node.bean.readFour(function(data) {
+                        node.bean.readFour(function(error, data) {
                             msg[node.property4] = valueOf(data, node.type4);
                             callback(null);
                         });
@@ -90,7 +90,7 @@ module.exports = function(RED) {
                 }
                 if (node.readFive) {
                     tasks.push(function(callback) {
-                        node.bean.readFive(function(data) {
+                        node.bean.readFive(function(error, data) {
                             msg[node.property5] = valueOf(data, node.type5);
                             callback(null);
                         });


### PR DESCRIPTION
@raykamp @aderhgawen 

This fixes the inability to read scratch characteristics. Users have reported that the value returned is always `null`. This is because the callback provided does not have the correct parameter signature... it needs to be `callback(error, data)`.  I figured this out by digging through about ~8 layers of abstraction until finally it's passed all way into the `noble` characteristic `.read()` call.